### PR TITLE
ci: added base workflow for docker images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -55,6 +55,8 @@ jobs:
         run: |
           echo "The name:tag of the Docker Image is: ${{ steps.meta.outputs.tags }}"
           echo "The labels are ${{ steps.meta.outputs.labels }}"
+
+      - name: Comment on PR
         uses: actions/github-script@v3
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This PR will focus on adding the docker build and push workflow jobs,  there will be a separate PR made for automated draft release notes generation.

The following tasks mentioned in #1 will be completed with this PR
- [x] Setup Github action to build the "tlnt" docker image
- [x] Setup docker builds to publish using PR number + git sha on PR's the github container registry
- [x] Setup docker build to publish using semver and publish to the github container registry. 

The versions can be found here https://github.com/Decentralized-Pictures/T4L3NT/pkgs/container/t4l3nt/versions

Signed-off-by: GImbrailo <ginoimbrailo@gmail.com>