### PR TITLE
Build Docker image on multiple CPU architectures

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: Build and Publish Docker image
 
 on:
   push:
@@ -12,20 +12,20 @@ on:
       - 'v*'
 
 jobs:
-
-  build-and-push:
-
-    runs-on: ubuntu-latest
-
+  build-and-publish:
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Registry login
-        uses: docker/login-action@v1
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          platforms: all
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
       - name: Extract metadata
         id: meta
@@ -38,8 +38,14 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
+      - name: Registry login
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v2.8.0
         with:
           context: .
           push: true


### PR DESCRIPTION
Ref #7

Add the [docker/setup-qemu-action](https://github.com/docker/setup-qemu-action) and [docker/setup-buildx-action](https://github.com/docker/setup-buildx-action) to the Docker build pipeline in order to build the Docker image on multiple platforms and architectures.

`docker/setup-qemu-action` full list of supported platform
```
supported": [
      "linux/amd64",
      "linux/arm64",
      "linux/riscv64",
      "linux/ppc64le",
      "linux/s390x",
      "linux/386",
      "linux/mips64le",
      "linux/mips64",
      "linux/arm/v7",
      "linux/arm/v6"
    ],
```