### PR TITLE
docker: add exec to fix graceful stop

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,4 +2,4 @@
 
 setup.sh
 
-supervisord -c /etc/supervisor/supervisord.conf -n
+exec supervisord -c /etc/supervisor/supervisord.conf -n


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/88539015/184084541-fd1a430e-e613-4a77-88f2-ad0441d8cadc.png)

pid of supervisor is not 1